### PR TITLE
Make reconcile concurrency configurable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,7 @@ jobs:
             - `--namespace`: The namespace the operator reacts on trigger events. Default is all namespaces.
             - `--label-selectors`: The label selectors the operator reacts on trigger events.
             - `--field-selectors`: The field selectors the operator reacts on trigger events.
+            - `--max-concurrent-reconciles`: The maximum number of concurrent Reconciles which can be run. Default: 1.
 
             > Requires `WatchList` feature gate enabled.
 

--- a/internal/controller/httptrigger_controller.go
+++ b/internal/controller/httptrigger_controller.go
@@ -719,7 +719,7 @@ func (r *HTTPTriggerReconciler) WatchInit(ctx context.Context) error {
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *HTTPTriggerReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, wg *sync.WaitGroup) error {
+func (r *HTTPTriggerReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, maxConcurrentReconciles int, wg *sync.WaitGroup) error {
 	r.ctx = ctx
 	r.runningTriggersLock = sync.Mutex{}
 	r.runningTriggers = map[string]func(){}
@@ -752,7 +752,7 @@ func (r *HTTPTriggerReconciler) SetupWithManager(ctx context.Context, mgr ctrl.M
 		Named("httptrigger").
 		WithOptions(controller.Options{
 			NeedLeaderElection:      ptr.To(true),
-			MaxConcurrentReconciles: 1,
+			MaxConcurrentReconciles: maxConcurrentReconciles,
 			RecoverPanic:            ptr.To(true),
 			Logger:                  mgr.GetLogger(),
 		}).


### PR DESCRIPTION
Make reconcile concurrency configurable to achieve better watcher creation performance.

Fixes: https://github.com/HariKube/serverless-kube-watch-trigger/issues/25